### PR TITLE
Update repo metadata for transfer to PDLPorters

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -132,9 +132,9 @@ my $builder = Alien::Base::ModuleBuild->new (
     
     meta_merge => {
 	resources => {
-	    homepage => 'https://github.com/drzowie/Alien-FFTW3',
-	    bugtracker => 'https://github.com/drzowie/Alien-FFTW3/issues',
-	    repository => 'git://github.com/ddrzowie/Alien-FFTW3.git'
+	    homepage => 'https://github.com/PDLPorters/Alien-FFTW3',
+	    bugtracker => 'https://github.com/PDLPorters/Alien-FFTW3/issues',
+	    repository => 'git://github.com/PDLPorters/Alien-FFTW3.git'
 	}
     }
     );


### PR DESCRIPTION
This is not strictly necessary because GitHub sets up redirects, but
good to get out of the way now.
